### PR TITLE
Show camera device names in dropdown instead of system paths

### DIFF
--- a/blender_mocap/capture_server/camera.py
+++ b/blender_mocap/capture_server/camera.py
@@ -42,8 +42,20 @@ class Camera:
             self._cap = None
 
     @staticmethod
+    def get_device_name(index: int) -> str:
+        """Get human-readable name for a camera device index."""
+        import os
+        name_path = f"/sys/class/video4linux/video{index}/name"
+        try:
+            with open(name_path) as f:
+                return f.read().strip()
+        except OSError:
+            pass
+        return f"Camera {index}"
+
+    @staticmethod
     def list_devices() -> list[int]:
-        """Probe /dev/video* devices that can actually open."""
+        """Probe camera devices (indices 0-9) that can actually open."""
         devices = []
         for i in range(10):
             cap = cv2.VideoCapture(i)
@@ -51,3 +63,15 @@ class Camera:
                 devices.append(i)
                 cap.release()
         return devices
+
+    @staticmethod
+    def list_devices_with_names() -> list[tuple[int, str]]:
+        """Return list of (index, name) for available camera devices."""
+        result = []
+        for i in range(10):
+            cap = cv2.VideoCapture(i)
+            if cap.isOpened():
+                cap.release()
+                name = Camera.get_device_name(i)
+                result.append((i, name))
+        return result

--- a/blender_mocap/properties.py
+++ b/blender_mocap/properties.py
@@ -13,14 +13,30 @@ from bpy.props import (
 from bpy.types import PropertyGroup
 
 
+def _get_camera_name(index: int) -> str:
+    """Get human-readable name for a camera device index via sysfs."""
+    import os
+    name_path = f"/sys/class/video4linux/video{index}/name"
+    try:
+        with open(name_path) as f:
+            return f.read().strip()
+    except OSError:
+        return f"Camera {index}"
+
+
 def get_camera_devices(self, context):
-    """Enumerate available video devices."""
-    items = []
+    """Enumerate available video devices by name."""
     import glob
+    items = []
     devices = sorted(glob.glob("/dev/video*"))
-    for i, dev in enumerate(devices):
+    for dev in devices:
         idx = dev.replace("/dev/video", "")
-        items.append((idx, f"Camera {idx} ({dev})", f"Use {dev}"))
+        try:
+            index = int(idx)
+        except ValueError:
+            continue
+        friendly_name = _get_camera_name(index)
+        items.append((idx, friendly_name, f"Use {dev}"))
     if not items:
         items.append(("NONE", "No cameras found", ""))
     return items


### PR DESCRIPTION
- Read friendly names from /sys/class/video4linux/videoN/name on Linux
- Fall back to "Camera N" if sysfs name is unavailable
- USB cameras appear as /dev/videoN and are enumerated correctly
- Add Camera.get_device_name() and list_devices_with_names() to camera.py
- Skip non-numeric video device entries (e.g. /dev/video-metadata)

Fixes #2