### PR TITLE
fix: handle ConnectionResetError when capture server crashes on startup

### DIFF
--- a/blender_mocap/ipc_client.py
+++ b/blender_mocap/ipc_client.py
@@ -31,7 +31,10 @@ class IPCClient:
                     return json.loads(line)
             ready, _, _ = select.select([self._sock], [], [], min(deadline, 0.5))
             if ready:
-                data = self._sock.recv(8192)
+                try:
+                    data = self._sock.recv(8192)
+                except OSError:
+                    return None  # Server disconnected or crashed
                 if not data:
                     return None  # Server disconnected
                 self._buffer += data.decode("utf-8")
@@ -50,7 +53,10 @@ class IPCClient:
             ready, _, _ = select.select([self._sock], [], [], 0)
             if not ready:
                 break
-            data = self._sock.recv(65536)
+            try:
+                data = self._sock.recv(65536)
+            except OSError:
+                break
             if not data:
                 break
             self._buffer += data.decode("utf-8")

--- a/blender_mocap/operators.py
+++ b/blender_mocap/operators.py
@@ -70,8 +70,16 @@ class MOCAP_OT_start_preview(Operator):
         _ipc_client = client
 
         # Read handshake
-        hello = _ipc_client.read_message(timeout=5.0)
-        if not hello or hello.get("protocol_version") != 1:
+        try:
+            hello = _ipc_client.read_message(timeout=5.0)
+        except OSError:
+            hello = None
+        if hello is None:
+            self.report({"ERROR"}, "Capture server failed to start — check that OpenCV and MediaPipe are installed")
+            _ipc_client.close()
+            _capture_process.stop()
+            return {"CANCELLED"}
+        if hello.get("protocol_version") != 1:
             self.report({"ERROR"}, "Protocol version mismatch")
             _ipc_client.close()
             _capture_process.stop()


### PR DESCRIPTION
When the capture server subprocess crashes before sending the handshake (e.g. due to missing OpenCV/MediaPipe dependencies or camera failure), the client received a raw ConnectionResetError traceback instead of a clean error message.

- ipc_client.py: Catch OSError in read_message() and drain_latest_pose() recv() calls, returning None on connection failure instead of raising
- operators.py: Wrap read_message() call in try/except; split the error message to distinguish server crash (None response) from protocol mismatch (wrong version number)