### PR TITLE
fix: report camera errors to client and send heartbeats while previewing

### DIFF
--- a/blender_mocap/capture_server/__main__.py
+++ b/blender_mocap/capture_server/__main__.py
@@ -70,7 +70,12 @@ def main() -> None:
             action = cmd.get("action", "")
             if action == "start_preview":
                 if not previewing:
-                    camera.open()
+                    try:
+                        camera.open()
+                    except RuntimeError as e:
+                        ipc.send({"type": "error", "message": str(e)})
+                        running = False
+                        continue
                     preview.open()
                     previewing = True
                     ipc.send({"type": "status", "state": "ready", "message": "Preview started"})
@@ -112,6 +117,7 @@ def main() -> None:
         # Capture and process frame
         if previewing:
             ret, frame = camera.read()
+            pose_sent = False
             if ret and frame is not None:
                 frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                 landmarks = estimator.estimate(frame_rgb)
@@ -120,6 +126,8 @@ def main() -> None:
                     t = time.time()
                     smoothed = smoother(t, landmarks)
                     ipc.send({"type": "pose", "landmarks": smoothed, "timestamp": t})
+                    last_heartbeat = t
+                    pose_sent = True
                     if not preview.update(frame, smoothed):
                         running = False
                 else:
@@ -127,6 +135,15 @@ def main() -> None:
                         running = False
             else:
                 time.sleep(0.001)
+            # Send heartbeat when no pose data (camera failure or no landmarks)
+            if not pose_sent:
+                now = time.time()
+                if now - last_heartbeat >= heartbeat_interval:
+                    try:
+                        ipc.send_heartbeat()
+                        last_heartbeat = now
+                    except (OSError, BrokenPipeError):
+                        running = False
         else:
             # Not previewing — send heartbeats
             now = time.time()

--- a/blender_mocap/operators.py
+++ b/blender_mocap/operators.py
@@ -356,6 +356,15 @@ def _poll_poses() -> float | None:
     if pose is not None or other_msgs:
         _last_message_time = now
 
+    # Check for server-reported errors
+    for msg in other_msgs:
+        if msg.get("type") == "error":
+            props.status = f"Error: {msg.get('message', 'Unknown error')}"
+            props.is_previewing = False
+            _ipc_client.close()
+            _capture_process.stop()
+            return None
+
     if pose is None:
         return 0.033  # Continue polling
     landmarks = pose["landmarks"]


### PR DESCRIPTION
Fixes #1

Three issues caused "Server not responding" after clicking Start Preview:

1. `camera.open()` raising `RuntimeError` was unhandled — server crashed silently; client waited 5s before showing generic timeout error.
2. No heartbeats sent while previewing if no landmarks detected or camera read failed — liveness timer expired.
3. Client's `_poll_poses()` discarded error-type messages from server.

Generated with [Claude Code](https://claude.ai/code)